### PR TITLE
Bump dependency versions, add basic backend test, cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/termhn/sdfu"
 readme = "README.md"
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 vek = { version = "0.9", optional = true }
 nalgebra = { version = "0.18", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ vek = { version = "0.9", optional = true }
 nalgebra = { version = "0.18", optional = true }
 ultraviolet = { version = "0.4", optional = true }
 # ultraviolet = { path = "../ultraviolet", optional=true }
+
+[dev-dependencies]
+vek = "0.9"
+nalgebra = "0.18"
+ultraviolet = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ all-features = true
 
 [dependencies]
 vek = { version = "0.9", optional = true }
-nalgebra = { version = "0.18", optional = true }
+nalgebra = { version = "0.24", optional = true }
 ultraviolet = { version = "0.4", optional = true }
 # ultraviolet = { path = "../ultraviolet", optional=true }
 
 [dev-dependencies]
 vek = "0.9"
-nalgebra = "0.18"
+nalgebra = "0.24"
 ultraviolet = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-vek = { version = "0.9", optional = true }
+vek = { version = "0.14", optional = true }
 nalgebra = { version = "0.24", optional = true }
 ultraviolet = { version = "0.4", optional = true }
 # ultraviolet = { path = "../ultraviolet", optional=true }
 
 [dev-dependencies]
-vek = "0.9"
+vek = "0.14"
 nalgebra = "0.24"
 ultraviolet = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-vek = { version = "0.14", optional = true }
-nalgebra = { version = "0.24", optional = true }
-ultraviolet = { version = "0.7", optional = true }
+vek = { version = "0.15", optional = true }
+nalgebra = { version = "0.27", optional = true }
+ultraviolet = { version = "0.8", optional = true }
 # ultraviolet = { path = "../ultraviolet", optional=true }
 
 [dev-dependencies]
-vek = "0.14"
-nalgebra = "0.24"
-ultraviolet = "0.7"
+vek = "0.15"
+nalgebra = "0.27"
+ultraviolet = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ all-features = true
 [dependencies]
 vek = { version = "0.14", optional = true }
 nalgebra = { version = "0.24", optional = true }
-ultraviolet = { version = "0.4", optional = true }
+ultraviolet = { version = "0.7", optional = true }
 # ultraviolet = { path = "../ultraviolet", optional=true }
 
 [dev-dependencies]
 vek = "0.14"
 nalgebra = "0.24"
-ultraviolet = "0.4"
+ultraviolet = "0.7"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ This is a small crate designed to help when working with signed distance fields
 in the context of computer graphics, especially ray-marching based renderers. Most
 of what is here is based on [Inigo Quilez' excellent articles](http://www.iquilezles.org/www/index.htm).
 
-If you're using one of the more popular math libraries in Rust (currently, `nalgebra` or `vek`), then just enable
-the corresponding feature and hopefully all the necessary traits are already implemented
-for you so that you can just start passing in your `Vec3`s or whatever your lib calls them
-and you're off to the races! If not, then you can implement the necessary traits in the
-`mathtypes` module and still use this library with your own math lib.
+If you're using one of the more popular math libraries in Rust, then just enable the corresponding
+feature (currently, [`ultraviolet`](https://github.com/termhn/ultraviolet), `nalgebra` and `vek`
+are supported) and hopefully all the necessary traits are already implemented for you so that
+you can just start passing in your `Vec3`s or whatever your lib calls them and you're off to the
+races! If not, then you can implement the necessary traits in the `mathtypes` module and still use
+this library with your own math lib.
 
 # Demo
 
@@ -19,6 +20,7 @@ by leveraging `sdfu`. The SDF that is rendered above was created with the follow
 
 ```rust
 use sdfu::SDF;
+use ultraviolet::Vec3;
 
 let sdf = sdfu::Sphere::new(0.45)
     .subtract(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,12 @@
 //! in the context of computer graphics, especially ray-marching based renderers. Most
 //! of what is here is based on [Inigo Quilez' excellent articles](http://www.iquilezles.org/www/index.htm).
 //!
-//! If you're using one of the more popular math libraries in Rust, then just enable
-//! the corresponding feature and hopefully all the necessary traits are already implemented
-//! for you so that you can just start passing in your `Vec3`s or whatever your lib calls them
-//! and you're off to the races! If not, then you can implement the necessary traits in the
-//! `mathtypes` module and still use this library with your own math lib.
+//! If you're using one of the more popular math libraries in Rust, then just enable the corresponding
+//! feature (currently, [`ultraviolet`](https://github.com/termhn/ultraviolet), `nalgebra` and `vek`
+//! are supported) and hopefully all the necessary traits are already implemented for you so that
+//! you can just start passing in your `Vec3`s or whatever your lib calls them and you're off to the
+//! races! If not, then you can implement the necessary traits in the `mathtypes` module and still use
+//! this library with your own math lib.
 //!
 //! This crate is built around the central trait `SDF`. This trait is structured in a similar way to
 //! how `std::iter::Iterator` works. Anything that implements `SDF` is able to return a distance from
@@ -27,7 +28,10 @@
 //! by leveraging `sdfu`. The SDF that is rendered above was created with the following code:
 //!
 //! ```rust
+//! # #[cfg(feature = "ultraviolet")]
+//! # fn main() {
 //! use sdfu::SDF;
+//! use ultraviolet::Vec3;
 //!
 //! let sdf = sdfu::Sphere::new(0.45)
 //!     .subtract(
@@ -47,6 +51,9 @@
 //!     .subtract(
 //!         sdfu::Box::new(Vec3::new(0.2, 2.0, 0.2)))
 //!     .translate(Vec3::new(0.0, 0.0, -1.0));
+//! # }
+//! # #[cfg(not(feature = "ultraviolet"))]
+//! # fn main() {}
 //! ```
 pub mod mathtypes;
 use mathtypes::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub trait SDF<T, V: Vec<T>>: Copy {
     ) -> Union<T, Self, O, M> {
         Union::new(self, other, min_function)
     }
-    /// Get the subtracion of another SDF from this one. Note that this operation is *not* commutative,
+    /// Get the subtraction of another SDF from this one. Note that this operation is *not* commutative,
     /// i.e. `a.subtraction(b) =/= b.subtraction(a)`.
     fn subtract<O: SDF<T, V>>(self, other: O) -> Subtraction<O, Self> {
         Subtraction::new(other, self)

--- a/src/mathtypes.rs
+++ b/src/mathtypes.rs
@@ -477,7 +477,14 @@ pub mod ultraviolet_integration {
         };
     }
 
-    impl_numerics!(uv::Vec2, uv::Vec2x4, uv::Vec2x8, uv::Vec3, uv::Vec3x4, uv::Vec3x8);
+    impl_numerics!(
+        uv::Vec2,
+        uv::Vec2x4,
+        uv::Vec2x8,
+        uv::Vec3,
+        uv::Vec3x4,
+        uv::Vec3x8
+    );
 
     macro_rules! impl_vec2 {
         ($($vt:ty => $t:ty),+) => {
@@ -495,7 +502,7 @@ pub mod ultraviolet_integration {
             )+
         }
     }
-    impl_vec2!(uv::Vec2 => f32, uv::Vec2x4 => f32x4);
+    impl_vec2!(uv::Vec2 => f32, uv::Vec2x4 => f32x4, uv::Vec2x8 => f32x8);
 
     macro_rules! impl_vec3 {
         ($($vt:ty => $t:ty),+) => {
@@ -513,7 +520,7 @@ pub mod ultraviolet_integration {
             })+
         }
     }
-    impl_vec3!(uv::Vec3 => f32, uv::Vec3x4 => f32x4);
+    impl_vec3!(uv::Vec3 => f32, uv::Vec3x4 => f32x4, uv::Vec3x8 => f32x8);
 
     macro_rules! impl_vec_vec2 {
         ($($vt:ty, $v3t:ty => $t:ty),+) => {
@@ -544,7 +551,7 @@ pub mod ultraviolet_integration {
             })+
         }
     }
-    impl_vec_vec2!(uv::Vec2, uv::Vec3 => f32, uv::Vec2x4, uv::Vec3x4 => f32x4);
+    impl_vec_vec2!(uv::Vec2, uv::Vec3 => f32, uv::Vec2x4, uv::Vec3x4 => f32x4, uv::Vec2x8, uv::Vec3x8 => f32x8);
 
     macro_rules! impl_vec_vec3 {
         ($($vt:ty, $v2t:ty => $t:ty),+) => {
@@ -575,7 +582,7 @@ pub mod ultraviolet_integration {
             })+
         }
     }
-    impl_vec_vec3!(uv::Vec3, uv::Vec2 => f32, uv::Vec3x4, uv::Vec2x4 => f32x4);
+    impl_vec_vec3!(uv::Vec3, uv::Vec2 => f32, uv::Vec3x4, uv::Vec2x4 => f32x4, uv::Vec3x8, uv::Vec2x8 => f32x8);
 
     macro_rules! impl_rotation_rotor {
         {$($rt:ty => $vt:ty),+} => {
@@ -591,8 +598,10 @@ pub mod ultraviolet_integration {
     impl_rotation_rotor! {
         uv::Rotor2 => uv::Vec2,
         uv::Rotor2x4 => uv::Vec2x4,
+        uv::Rotor2x8 => uv::Vec2x8,
         uv::Rotor3 => uv::Vec3,
-        uv::Rotor3x4 => uv::Vec3x4
+        uv::Rotor3x4 => uv::Vec3x4,
+        uv::Rotor3x8 => uv::Vec3x8
     }
 }
 

--- a/src/mathtypes.rs
+++ b/src/mathtypes.rs
@@ -29,7 +29,7 @@ pub trait Vec<T>:
     fn normalized(&self) -> Self;
 }
 
-/// Functionality that must be implmeented by 3D vectors.
+/// Functionality that must be implemented by 3D vectors.
 pub trait Vec3<T>: Vec<T> {
     fn new(x: T, y: T, z: T) -> Self;
     fn x(&self) -> T;
@@ -37,14 +37,14 @@ pub trait Vec3<T>: Vec<T> {
     fn z(&self) -> T;
 }
 
-/// Functionality that must be implmeented by 2D vectors.
+/// Functionality that must be implemented by 2D vectors.
 pub trait Vec2<T>: Vec<T> {
     fn new(x: T, y: T) -> Self;
     fn x(&self) -> T;
     fn y(&self) -> T;
 }
 
-/// A trait used to mark the dimensionality of a vector/SDF/implmentation
+/// A trait used to mark the dimensionality of a vector/SDF/implementation
 /// of an SDF combinator.
 pub trait Dimension {}
 
@@ -52,7 +52,7 @@ pub trait Dimension {}
 #[derive(Clone, Copy, Debug)]
 pub struct Dim2D {}
 
-/// 2D marker struct.
+/// 3D marker struct.
 #[derive(Clone, Copy, Debug)]
 pub struct Dim3D {}
 

--- a/src/mathtypes.rs
+++ b/src/mathtypes.rs
@@ -218,7 +218,7 @@ pub trait Exp2 {
 impl Exp2 for f32x4 {
     #[inline]
     fn exp2(&self) -> Self {
-        f32x4::exp2(*self)
+        f32x4::from(2.0).pow_f32x4(*self)
     }
 }
 
@@ -517,7 +517,7 @@ pub mod ultraviolet_integration {
         };
     }
 
-    impl_numerics!(uv::Vec2, uv::Wec2, uv::Vec3, uv::Wec3);
+    impl_numerics!(uv::Vec2, uv::Vec2x4, uv::Vec2x8, uv::Vec3, uv::Vec3x4, uv::Vec3x8);
 
     macro_rules! impl_vec2 {
         ($($vt:ty => $t:ty),+) => {
@@ -535,7 +535,7 @@ pub mod ultraviolet_integration {
             )+
         }
     }
-    impl_vec2!(uv::Vec2 => f32, uv::Wec2 => f32x4);
+    impl_vec2!(uv::Vec2 => f32, uv::Vec2x4 => f32x4);
 
     macro_rules! impl_vec3 {
         ($($vt:ty => $t:ty),+) => {
@@ -553,7 +553,7 @@ pub mod ultraviolet_integration {
             })+
         }
     }
-    impl_vec3!(uv::Vec3 => f32, uv::Wec3 => f32x4);
+    impl_vec3!(uv::Vec3 => f32, uv::Vec3x4 => f32x4);
 
     macro_rules! impl_vec_vec2 {
         ($($vt:ty, $v3t:ty => $t:ty),+) => {
@@ -584,7 +584,7 @@ pub mod ultraviolet_integration {
             })+
         }
     }
-    impl_vec_vec2!(uv::Vec2, uv::Vec3 => f32, uv::Wec2, uv::Wec3 => f32x4);
+    impl_vec_vec2!(uv::Vec2, uv::Vec3 => f32, uv::Vec2x4, uv::Vec3x4 => f32x4);
 
     macro_rules! impl_vec_vec3 {
         ($($vt:ty, $v2t:ty => $t:ty),+) => {
@@ -615,7 +615,7 @@ pub mod ultraviolet_integration {
             })+
         }
     }
-    impl_vec_vec3!(uv::Vec3, uv::Vec2 => f32, uv::Wec3, uv::Wec2 => f32x4);
+    impl_vec_vec3!(uv::Vec3, uv::Vec2 => f32, uv::Vec3x4, uv::Vec2x4 => f32x4);
 
     macro_rules! impl_rotation_rotor {
         {$($rt:ty => $vt:ty),+} => {
@@ -630,9 +630,9 @@ pub mod ultraviolet_integration {
 
     impl_rotation_rotor! {
         uv::Rotor2 => uv::Vec2,
-        uv::WRotor2 => uv::Wec2,
+        uv::Rotor2x4 => uv::Vec2x4,
         uv::Rotor3 => uv::Vec3,
-        uv::WRotor3 => uv::Wec3
+        uv::Rotor3x4 => uv::Vec3x4
     }
 }
 

--- a/src/mathtypes.rs
+++ b/src/mathtypes.rs
@@ -1,3 +1,5 @@
+//! Traits that have to implemented by vector and scalar traits to be used by this library.
+
 use std::ops::*;
 
 #[cfg(feature = "ultraviolet")]
@@ -179,7 +181,7 @@ impl PointFive for f64 {
 }
 
 /// Linear interpolate between self and other with a factor
-/// between Self::zero() and Self::one.
+/// between `Self::zero()` and `Self::one()`.
 pub trait Lerp {
     fn lerp(&self, other: Self, factor: Self) -> Self;
 }
@@ -270,6 +272,7 @@ pub trait Rotation<V> {
 }
 
 #[cfg(feature = "vek")]
+#[doc(hidden)]
 pub mod vek_integration {
     use super::*;
 
@@ -470,6 +473,7 @@ pub mod vek_integration {
 }
 
 #[cfg(feature = "ultraviolet")]
+#[doc(hidden)]
 pub mod ultraviolet_integration {
     use super::*;
     use ultraviolet as uv;
@@ -649,6 +653,7 @@ impl Clamp for f64 {
 }
 
 #[cfg(feature = "nalgebra")]
+#[doc(hidden)]
 pub mod nalgebra_integration {
     use super::*;
     use nalgebra as na;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -79,7 +79,7 @@ where
 /// This uses a polynomial function to smooth between the two
 /// values, and `k` controls the radius/distance of the
 /// smoothing. 0.1 is a good default value for `k` for this
-/// smoothign function.
+/// smoothing function.
 #[derive(Clone, Copy, Debug)]
 pub struct PolySmoothMin<T> {
     pub k: T,
@@ -184,7 +184,7 @@ where
     }
 }
 
-/// Get the subtracion of two SDFs. Note that this operation is *not* commutative,
+/// Get the subtraction of two SDFs. Note that this operation is *not* commutative,
 /// i.e. `Subtraction::new(a, b) =/= Subtraction::new(b, a)`.
 #[derive(Clone, Copy, Debug)]
 pub struct Subtraction<S1, S2> {
@@ -193,7 +193,7 @@ pub struct Subtraction<S1, S2> {
 }
 
 impl<S1, S2> Subtraction<S1, S2> {
-    /// Get the subtracion of two SDFs. Note that this operation is *not* commutative,
+    /// Get the subtraction of two SDFs. Note that this operation is *not* commutative,
     /// i.e. `Subtraction::new(a, b) =/= Subtraction::new(b, a)`.
     pub fn new(sdf1: S1, sdf2: S2) -> Self {
         Subtraction { sdf1, sdf2 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -12,7 +12,7 @@ use crate::SDF;
 use std::marker::PhantomData;
 use std::ops::*;
 
-/// A shere centered at origin with a radius.
+/// A sphere centered at origin with a radius.
 #[derive(Clone, Copy, Debug)]
 pub struct Sphere<T> {
     pub radius: T,

--- a/tests/test_backends.rs
+++ b/tests/test_backends.rs
@@ -1,0 +1,26 @@
+#[cfg(feature = "nalgebra")]
+#[test]
+fn test_nalgebra() {
+    use sdfu::SDF;
+    let sdf = sdfu::Sphere::new(1.0);
+    let dist: f32 = sdf.dist(nalgebra::Vector3::zeros());
+    assert_eq!(dist, -1.0);
+}
+
+#[cfg(feature = "ultraviolet")]
+#[test]
+fn test_ultraviolet() {
+    use sdfu::SDF;
+    let sdf = sdfu::Sphere::new(1.0);
+    let dist: f32 = sdf.dist(ultraviolet::Vec3::zero());
+    assert_eq!(dist, -1.0);
+}
+
+#[cfg(feature = "vek")]
+#[test]
+fn test_vek() {
+    use sdfu::SDF;
+    let sdf = sdfu::Sphere::new(1.0);
+    let dist: f32 = sdf.dist(vek::vec::Vec3::zero());
+    assert_eq!(dist, -1.0);
+}


### PR DESCRIPTION
This PR
- Bumps all dependencies to their most recent version
- Adds basic tests to ensure that all vector "backend" implementations work (can be run with e.g. `cargo test --all-features`)
- Cleans up some of the trait impls using macros and changes the `Clamp` impl such that `--all-features` compiles
- Adds support for `ultraviolet`'s `f32x8` types and adapts impls to the changed naming conventions
- Fixes spelling of some doc comments

Just wanted to clean this up before trying to completely switch to `ultraviolet` (in case I don't have time to finish that) as we discussed in the issue https://github.com/termhn/sdfu/issues/4. Are you open to using GitHub actions? I can just copy a basic actions file from my repo to run `cargo check`, `cargo fmt --check` etc.?